### PR TITLE
Tested and fine-tuned `trk stop --at`, including usage of external packages, pytimeparse2` and `dateutils` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Summary
 * [**Unreleased**](#unreleased)
-* [**Release 2025-03-09 v0.3a2**](#release-2025-03-09-v03a3) Added stop --at test; Added report module
+* [**Release 2025-03-14 v0.3a4**](#release-2025-03-14-v03a4) Added stop --at test; Added report module
 * [**Release 2025-02-25 v0.3a0**](#release-2025-02-25-v03a0) Added --at functionality to start & stop command
 * **Release 2025-02-18 v0.2a5** Changed logo to a stopwatch
 * **Release 2025-02-18 v0.2a4** Added `trk time` command to report elapsed hours
@@ -20,7 +20,7 @@
 
 ## Unreleased
 
-## Release 2025-03-09 v0.3a3
+## Release 2025-03-14 v0.3a4
 * ADD stop --at test
 * ADD report command
   * Initial implementation works for a single user on a single project (more to come)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Time is saved in
 * [Quickstart](#quickstart)
 * [Installation](#installation)
 * [Other time-trackers](#other-timetrackers)
-* [Documentation](docs/index.md)
+* [Documentation](docs/README.md)
 
 ## Advantages
 * Freedom Software (aka open-source)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ $ pip install .
 
 ## Other timetrackers
 * 700+ stars [Bartib](https://github.com/nikolassv/bartib)
+* 740+ stars [timetrace](https://github.com/dominikbraun/timetrace)
 * 13k stars [ActivityWatch](https://github.com/ActivityWatch/activitywatch)
 * 85 stars [ti](https://github.com/richmeta/ti)
 * 44 stars [tim](https://github.com/MatthiasKauer/tim)

--- a/makefile
+++ b/makefile
@@ -16,23 +16,23 @@ pn:
 DIRTRK = ./.trkr
 PROJ = trk
 trk:
-	trk --trksubdir $(DIRTRK)
+	trk --trk-dir $(DIRTRK)
 
 # -----------------------------------------------------------------------------
 init:
 	rm -rf $(DIRTRK)
-	trk --trksubdir $(DIRTRK) init --project $(PROJ) --csvdir ~/timetrackers
+	trk --trk-dir $(DIRTRK) init --project $(PROJ) --csvdir ~/timetrackers
 	find $(DIRTRK)
 
 start:
-	trk --trksubdir $(DIRTRK) start
+	trk --trk-dir $(DIRTRK) start
 	find $(DIRTRK)
 	@grep -Hw --color filename $(DIRTRK)/config
 	@ls -lrt ~/timetrackers/timetracker_trk_$(USER).csv
 	find $(DIRTRK)
 
 cancel:
-	trk --trksubdir $(DIRTRK) cancel
+	trk --trk-dir $(DIRTRK) cancel
 	find $(DIRTRK)
 	@grep -Hw --color filename $(DIRTRK)/config
 	@ls -lrt ~/timetrackers/timetracker_trk_$(USER).csv
@@ -51,24 +51,24 @@ stop:
 	fi
 
 _stop:
-	#trk --trksubdir $(DIRTRK) stop -m "\"$(M)\""
-	trk --trksubdir $(DIRTRK) stop -m "$(M)"
+	#trk --trk-dir $(DIRTRK) stop -m "\"$(M)\""
+	trk --trk-dir $(DIRTRK) stop -m "$(M)"
 	find $(DIRTRK)
 	grep filename $(DIRTRK)/config
 	#find ~/timetrackers/ -type f -name \*.csv
 
 report:
-	trk --trksubdir $(DIRTRK) report
+	trk --trk-dir $(DIRTRK) report
 
 csv:
-	trk --trksubdir $(DIRTRK) csv
+	trk --trk-dir $(DIRTRK) csv
 
 time:
-	trk --trksubdir $(DIRTRK) time
+	trk --trk-dir $(DIRTRK) time
 
 docx:
-	trk --trksubdir $(DIRTRK) time -i $(CSV)
-	trk --trksubdir $(DIRTRK) invoice -i $(CSV) -o timetracker.docx
+	trk --trk-dir $(DIRTRK) time -i $(CSV)
+	trk --trk-dir $(DIRTRK) invoice -i $(CSV) -o timetracker.docx
 
 	
 files:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "timetracker-csv"
-version = "0.3a3"
+version = "0.3a4"
 dynamic = [
     "dependencies",
     "scripts",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     # The name of the project on PyPi
     name='timetracker-csv',
     # https://peps.python.org/pep-0440/
-    version='0.3a3',
+    version='0.3a4',
     author='DV Klopfenstein, PhD',
     author_email='dvklopfenstein@protonmail.com',
     packages=PACKAGES,

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -3,7 +3,6 @@
 
 from os.path import join
 from os.path import exists
-from os.path import dirname
 from os.path import expanduser
 from logging import debug
 from logging import DEBUG

--- a/tests/test_cfg_global.py
+++ b/tests/test_cfg_global.py
@@ -9,6 +9,7 @@ from logging import debug
 from logging import DEBUG
 from logging import basicConfig
 from tempfile import TemporaryDirectory
+from timetracker.consts import FILENAME_GLOBALCFG
 from timetracker.cfg.cfg_global import CfgGlobal
 from timetracker.cfg.cfg_local import CfgProj
 #from timetracker.cfg.utils import get_relpath_adj
@@ -23,7 +24,7 @@ SEP = f'{"-"*80}\n'
 def test_cfgbase_home():
     """Test instantiating a default CfgGlobal"""
     with TemporaryDirectory() as tmphome:
-        cfg = CfgGlobal(tmphome)
+        cfg = CfgGlobal(join(tmphome, FILENAME_GLOBALCFG))
         assert cfg.filename == join(tmphome, '.timetrackerconfig')
         assert cfg.doc['projects'] == []
         assert not exists(cfg.filename)
@@ -71,7 +72,7 @@ def test_cfgbase_temp(trksubdir='.timetracker'):
 
 def _get_cfgglobal_empty(tmphome):
     """Write and get an empty Global Configuration file/object"""
-    cfgtop = CfgGlobal(tmphome)
+    cfgtop = CfgGlobal(join(tmphome, FILENAME_GLOBALCFG))
     assert cfgtop.filename == join(tmphome, '.timetrackerconfig'), f'{cfgtop.filename}'
     doc = cfgtop.rd_cfg()
     assert doc is None
@@ -88,12 +89,14 @@ def _get_cfgglobal_empty(tmphome):
 
 def test_dirhome():
     """Test the TimeTracker global configuration"""
-    cfg = CfgGlobal()
-    assert dirname(cfg.filename) == expanduser('~')
+    fcfg = join(expanduser('~'), FILENAME_GLOBALCFG)
+    cfg = CfgGlobal(fcfg)
+    assert cfg.filename == fcfg, f'{cfg.filename} != {fcfg}'
 
     with TemporaryDirectory() as tmphome:
-        cfg = CfgGlobal(tmphome)
-        assert dirname(cfg.filename) == tmphome
+        fcfg = join(tmphome, FILENAME_GLOBALCFG)
+        cfg = CfgGlobal(fcfg)
+        assert cfg.filename == fcfg
 
 
 if __name__ == '__main__':

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,13 +34,13 @@ def test_basic():
 
 def test_dir():
     """Test the basic timetracker flow"""
-    mainargs = '--trksubdir .tt'.split()
+    mainargs = '--trk-dir .tt'.split()
     args = _trk_init(mainargs)
-    assert args.trksubdir == '.tt'
+    assert args.trk_dir == '.tt'
     args = _trk_start(mainargs)
-    assert args.trksubdir == '.tt'
+    assert args.trk_dir == '.tt'
     args = _trk_stop(mainargs)
-    assert args.trksubdir == '.tt'
+    assert args.trk_dir == '.tt'
 
 # ------------------------------------------------------------
 def _trk_stop(mainargs=None):
@@ -86,7 +86,7 @@ def _trk():
     args = _parse_args([])
     # TODO: Check that help message was printed
     # TODO: Check: Run `trk init` to initialize local timetracker
-    assert args.trksubdir == DIRTRK
+    assert args.trk_dir == DIRTRK
     assert args.name == environ['USER']
     assert not args.quiet
     assert args.command is None

--- a/tests/test_cli_dircsv_default.py
+++ b/tests/test_cli_dircsv_default.py
@@ -9,6 +9,7 @@ from logging import basicConfig
 from logging import DEBUG
 from logging import debug
 from tempfile import TemporaryDirectory
+from timetracker.consts import FILENAME_GLOBALCFG
 from timetracker.utils import cyan
 from timetracker.cfg.cfg_local import CfgProj
 from timetracker.cmd.init import run_init_test
@@ -61,7 +62,8 @@ class Obj:
             #assert not exists(cfgname), findhome_str(exp.dirhome)
 
             # CMD: INIT; CFG PROJECT
-            cfgp, cfgg = run_init_test(cfgname, dircsv, self.project, exp.dirhome)
+            fcfgg = join(exp.dirhome, FILENAME_GLOBALCFG)
+            cfgp, cfgg = run_init_test(cfgname, dircsv, self.project, fcfgg)
             # pylint: disable=unsubscriptable-object
             assert cfgp.read_doc()['csv']['filename'] == join(dircsv, CfgProj.CSVPAT)
             exp_cfg_csv_fname = join(dircsv, fcsv)

--- a/tests/test_cmdcsv.py
+++ b/tests/test_cmdcsv.py
@@ -2,9 +2,11 @@
 """Various tests when the project config file does not exist"""
 
 from os import system
+from os.path import join
 from logging import basicConfig
 #from logging import DEBUG
 from tempfile import TemporaryDirectory
+from timetracker.consts import FILENAME_GLOBALCFG
 from timetracker.cfg.finder import CfgFinder
 from timetracker.cmd.init import run_init_test
 from timetracker.cmd.start import run_start
@@ -34,7 +36,8 @@ def test_get_filename_csv():
         for projname, projdir in projname2projdir.items():
             finder = CfgFinder(projdir)
             cfgfilename = finder.get_cfgfilename()
-            run_init_test(cfgfilename, dircsv, projname, tmphome)
+            fcfgg = join(tmphome, FILENAME_GLOBALCFG)
+            run_init_test(cfgfilename, dircsv, projname, fcfgg)
             for idx in range(2, 12, 2):
                 run_start(cfgfilename, username, defaultdt=now, start_at=f'{idx}pm')
                 ntcsv = get_ntcsv(f'{projname} {username} {idx}')

--- a/tests/test_startat.py
+++ b/tests/test_startat.py
@@ -2,10 +2,12 @@
 """Test `trk start --at`"""
 
 from os.path import exists
+from os.path import join
 #from logging import basicConfig
 #from logging import DEBUG
 from logging import debug
 from tempfile import TemporaryDirectory
+from timetracker.consts import FILENAME_GLOBALCFG
 from timetracker.utils import cyan
 from timetracker.utils import yellow
 from timetracker.cmd.init import run_init_test
@@ -58,7 +60,8 @@ class Obj(RunBase):
             cfgname, _, exp = proj_setup(tmphome, self.project, self.dircur, self.dirgit01)
 
             # CMD: INIT; CFG PROJECT
-            cfgp, _ = run_init_test(cfgname, dircsv, self.project, exp.dirhome)  # cfgg
+            fcfgg = join(exp.dirhome, FILENAME_GLOBALCFG)
+            cfgp, _ = run_init_test(cfgname, dircsv, self.project, fcfgg)  # cfgg
             #findhome(tmphome)
 
             # CMD: START

--- a/tests/test_stopat.py
+++ b/tests/test_stopat.py
@@ -11,6 +11,7 @@ from logging import debug
 from logging import getLogger
 from tempfile import TemporaryDirectory
 from csv import writer
+from timetracker.consts import FILENAME_GLOBALCFG
 from timetracker.utils import cyan
 from timetracker.utils import yellow
 from timetracker.ntcsv import get_ntcsv
@@ -66,7 +67,8 @@ class Obj(RunBase):
         """Run init, stop --at, stop"""
         cfgname, _, exp = proj_setup(tmphome, self.project, self.dircur, self.dirgit01)
         # pylint: disable=unused-variable
-        cfgp, _ = run_init_test(cfgname, dircsv, self.project, exp.dirhome, quiet=True)  # cfgg
+        fcfgg = join(exp.dirhome, FILENAME_GLOBALCFG)
+        cfgp, _ = run_init_test(cfgname, dircsv, self.project, fcfgg, quiet=True)  # cfgg
         fin_start = run_start(cfgname, self.uname,
             now=dta,
             defaultdt=dta)

--- a/tests/test_trk_cmdsall.py
+++ b/tests/test_trk_cmdsall.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 from pytest import raises
 from timetracker.utils import cyan
 from timetracker.cmd.stop import run_stop
-from timetracker.cmd.time import run_time
+from timetracker.cmd.time import run_time_local
 from timetracker.cmd.cancel import run_cancel
 from timetracker.cmd.csvupdate import run_csvupdate
 from timetracker.cmd.report import run_report
@@ -55,7 +55,7 @@ class Obj(RunBase):
 
             # time       Report elapsed time
             with raises(SystemExit) as excinfo:
-                run_time(cfgname, uname)
+                run_time_local(cfgname, uname)
             assert excinfo.value.code == 0
 
             # report     Generate an report for all time units and include cumulative time

--- a/timetracker/__init__.py
+++ b/timetracker/__init__.py
@@ -2,6 +2,6 @@
 
 __copyright__ = 'Copyright (C) 2025-present, DV Klopfenstein, PhD. All rights reserved'
 __author__ = 'DV Klopfenstein, PhD'
-__version__ = '0.3a3'
+__version__ = '0.3a4'
 
 # Copyright (C) 2025-present, DV Klopfenstein, PhD. All rights reserved

--- a/timetracker/cfg/cfg_global.py
+++ b/timetracker/cfg/cfg_global.py
@@ -22,9 +22,9 @@ from tomlkit import array
 from tomlkit.toml_file import TOMLFile
 
 ##from timetracker.cfg.utils import replace_homepath
-from timetracker.consts import FILENAME_GLOBALCFG
+####from timetracker.consts import FILENAME_GLOBALCFG
 from timetracker.utils import ltblue
-from timetracker.cfg.utils import get_dirhome
+##from timetracker.cfg.utils import get_dirhome
 from timetracker.cfg.utils import has_homedir
 #from timetracker.cfg.utils import get_relpath_adj
 #from timetracker.consts import FILENAME_GLOBALCFG
@@ -33,12 +33,11 @@ from timetracker.cfg.utils import has_homedir
 class CfgGlobal:
     """Global configuration parser for timetracking"""
 
-    def __init__(self, dirhome='~', basename=FILENAME_GLOBALCFG):
-        self.dirhome = abspath(get_dirhome(dirhome))
-        self.filename = join(self.dirhome, basename)
-    ##def __init__(self, filename):
-    ##    self.dirhome = dirname(filename)
-    ##    self.filename = filename
+    ##def __init__(self, dirhome='~', basename=FILENAME_GLOBALCFG):
+    ##    self.dirhome = abspath(get_dirhome(dirhome))
+    ##    self.filename = join(self.dirhome, basename)
+    def __init__(self, filename):
+        self.filename = filename
         debug(ltblue(f'CfgGlobal CONFIG: exists({int(exists(self.filename))}) -- '
                    f'{self.filename}'))
         self.doc = self._init_docglobal()
@@ -82,12 +81,12 @@ class CfgGlobal:
     def _get_docprt(self):
         doc_cur = self.doc.copy()
         ##truehome = expanduser('~')
-        dirhome = self.dirhome
+        dirhome = dirname(self.filename)
         for idx, (projname, projdir) in enumerate(self.doc['projects'].unwrap()):
             ##pdir = relpath(abspath(projdir), truehome)
             ##pdir = relpath(abspath(projdir), dirhome)
             ##if pdir[:2] != '..':
-            if has_homedir(self.dirhome, abspath(projdir)):
+            if has_homedir(dirhome, abspath(projdir)):
                 ##pdir = join('~', pdir)
                 pdir = join('~', relpath(abspath(projdir), dirhome))
                 doc_cur['projects'][idx] = [projname, pdir]

--- a/timetracker/cfg/cfg_global.py
+++ b/timetracker/cfg/cfg_global.py
@@ -7,6 +7,7 @@ __author__ = "DV Klopfenstein, PhD"
 ##from os import environ
 from os.path import isabs
 from os.path import exists
+from os.path import dirname
 ##from os.path import expanduser
 ##from os.path import basename
 from os.path import join
@@ -21,12 +22,12 @@ from tomlkit import array
 from tomlkit.toml_file import TOMLFile
 
 ##from timetracker.cfg.utils import replace_homepath
+from timetracker.consts import FILENAME_GLOBALCFG
 from timetracker.utils import ltblue
 from timetracker.cfg.utils import get_dirhome
 from timetracker.cfg.utils import has_homedir
 #from timetracker.cfg.utils import get_relpath_adj
-
-FILENAME_GLOBALCFG = '.timetrackerconfig'
+#from timetracker.consts import FILENAME_GLOBALCFG
 
 
 class CfgGlobal:
@@ -35,6 +36,9 @@ class CfgGlobal:
     def __init__(self, dirhome='~', basename=FILENAME_GLOBALCFG):
         self.dirhome = abspath(get_dirhome(dirhome))
         self.filename = join(self.dirhome, basename)
+    ##def __init__(self, filename):
+    ##    self.dirhome = dirname(filename)
+    ##    self.filename = filename
         debug(ltblue(f'CfgGlobal CONFIG: exists({int(exists(self.filename))}) -- '
                    f'{self.filename}'))
         self.doc = self._init_docglobal()
@@ -125,6 +129,13 @@ class CfgGlobal:
         arr.multiline(True)
         doc["projects"] = arr
         return doc
+
+    #@staticmethod
+    #def _init_dirhome(filename):
+    #    if isdir(filename):
+    #        return filename, FILENAME_GLOBALCFG
+    #    if filename.endswith(FILENAME_GLOBALCFG):
+    #        return dirname, filename
 
 
 # Copyright (C) 2025-present, DV Klopfenstein, PhD. All rights reserved.

--- a/timetracker/cfg/utils.py
+++ b/timetracker/cfg/utils.py
@@ -151,9 +151,8 @@ def get_shortest_name(filename):
     frel = normpath(relpath(filename))
     return fabs if len(fabs) < len(frel) else frel
 
-def get_dirhome_globalcfg(dirhome=None):
+def get_dirhome_globalcfg():
     """Get the home directory, where the global configuration will be stored"""
-    assert not dirhome
     return expanduser('~') if 'TIMETRACKERCONF' not in environ else environ['TIMETRACKERCONF']
 
 

--- a/timetracker/cfg/utils.py
+++ b/timetracker/cfg/utils.py
@@ -20,6 +20,7 @@ from os.path import commonprefix
 from subprocess import run
 from logging import debug
 from logging import warning
+from timetracker.consts import FILENAME_GLOBALCFG
 
 def get_abspath(fnam, dirproj, dirhome=None):
     """Get the path of the path fnam relative to dirproj"""
@@ -153,7 +154,9 @@ def get_shortest_name(filename):
 
 def get_dirhome_globalcfg():
     """Get the home directory, where the global configuration will be stored"""
-    return expanduser('~') if 'TIMETRACKERCONF' not in environ else environ['TIMETRACKERCONF']
+    if 'TIMETRACKERCONF' not in environ:
+        return join(expanduser('~'), FILENAME_GLOBALCFG)
+    return environ['TIMETRACKERCONF']
 
 
 # Copyright (C) 2025-present, DV Klopfenstein, PhD. All rights reserved.

--- a/timetracker/cli.py
+++ b/timetracker/cli.py
@@ -33,7 +33,7 @@ class Cli:
     # pylint: disable=too-few-public-methods
 
     ARGV_TESTS = {
-        'trksubdir': set(['--trksubdir']),
+        'trksubdir': set(['--trk-dir']),
     }
 
     def __init__(self, args=None):
@@ -92,9 +92,9 @@ class Cli:
         found = False
         for arg in sys_argv:
             if found:
-                debug(f'Cli FOUND: argv --trksubdir {arg}')
+                debug(f'Cli FOUND: argv --trk-dir {arg}')
                 return arg
-            if arg == '--trksubdir':
+            if arg == '--trk-dir':
                 found = True
         return None
 
@@ -113,7 +113,7 @@ class Cli:
             description="Track your time repo by repo",
             formatter_class=ArgumentDefaultsHelpFormatter,
         )
-        parser.add_argument('--trksubdir', metavar='DIR', default=self.finder.trksubdir,
+        parser.add_argument('--trk-dir', metavar='DIR', default=self.finder.trksubdir,
             # Directory that holds the local project config file
             help='Directory that holds the local project config file')
             #help=SUPPRESS)

--- a/timetracker/cli.py
+++ b/timetracker/cli.py
@@ -134,8 +134,8 @@ class Cli:
         self._add_subparser_cancel(subparsers)
         self._add_subparser_time(subparsers)
         self._add_subparser_report(subparsers)
-        self._add_subparser_csv(subparsers)
-        self._add_subparser_csvupdate(subparsers)
+        self._add_subparser_projects(subparsers)
+        self._add_subparser_projectsupdate(subparsers)
         #help='timetracker subcommand help')
         ##self._add_subparser_files(subparsers)
         ##return parser
@@ -203,6 +203,8 @@ class Cli:
         parser = subparsers.add_parser(name='time',
             help='Report elapsed time',
             formatter_class=ArgumentDefaultsHelpFormatter)
+        #parser.add_argument('--global', action='store_true',
+        #    help='Report the elapsed time in hours on all projects')
         parser.add_argument('-u', '--unit', choices=['hours'], default=None,
             help='Report the elapsed time in hours')
         parser.add_argument('-i', '--input', metavar='file.csv',
@@ -223,15 +225,15 @@ class Cli:
             help=SUPPRESS)  # Future feature
         return parser
 
-    def _add_subparser_csv(self, subparsers):
-        parser = subparsers.add_parser(name='csv',
-            help='Show the locations of csv files managed by timetracker',
+    def _add_subparser_projects(self, subparsers):
+        parser = subparsers.add_parser(name='projects',
+            help='Show all projects and the locations of their csv files',
             formatter_class=ArgumentDefaultsHelpFormatter)
         parser.add_argument('-g', '--global', action='store_true',
-            help='Look for csv files for all projects tracked in the global config file')
+            help='Look for all projects and their csv files tracked in the global config file')
         return parser
 
-    def _add_subparser_csvupdate(self, subparsers):
+    def _add_subparser_projectsupdate(self, subparsers):
         parser = subparsers.add_parser(name='csvupdate',
             help='Update values in csv columns containing weekday, am/pm, and duration',
             formatter_class=ArgumentDefaultsHelpFormatter)

--- a/timetracker/cmd/init.py
+++ b/timetracker/cmd/init.py
@@ -26,13 +26,13 @@ def run_init(fnamecfg, dircsv, project, quiet=False):
     """Initialize timetracking on a project"""
     cfgproj = run_init_local(fnamecfg, dircsv, project, quiet)
     debug(cfgproj.get_desc("new"))
-    dirhome = get_dirhome_globalcfg()
-    run_init_global(dirhome, cfgproj)
+    filename_globalcfg = get_dirhome_globalcfg()
+    run_init_global(filename_globalcfg, cfgproj)
 
-def run_init_test(fnamecfg, dircsv, project, dirhome, quiet=False):
+def run_init_test(fnamecfg, dircsv, project, filename_globalcfg, quiet=False):
     """Initialize timetracking on a test project"""
     cfgproj = run_init_local(fnamecfg, dircsv, project, quiet)
-    cfg_global = run_init_global(dirhome, cfgproj)
+    cfg_global = run_init_global(filename_globalcfg, cfgproj)
     return cfgproj, cfg_global
 
 def run_init_local(fnamecfg, dircsv, project, quiet=True):
@@ -49,10 +49,10 @@ def run_init_local(fnamecfg, dircsv, project, quiet=True):
     cfgproj.write_file(dircsv=dircsv, quiet=quiet)
     return cfgproj
 
-def run_init_global(dirhome, cfgproj):
+def run_init_global(filename_globalcfg, cfgproj):
     """Initialize the global configuration file for a timetracking project"""
     # 4. WRITE A GLOBAL TIMETRACKER CONFIG FILE: ~/.timetrackerconfig, if needed
-    cfg_global = CfgGlobal(dirhome)
+    cfg_global = CfgGlobal(filename_globalcfg)
     chgd = cfg_global.add_proj(cfgproj.project, cfgproj.get_filename_cfg())
     if chgd:
         cfg_global.wr_cfg()

--- a/timetracker/cmd/projects.py
+++ b/timetracker/cmd/projects.py
@@ -6,37 +6,39 @@ __author__ = "DV Klopfenstein, PhD"
 from os.path import exists
 from logging import debug
 from timetracker.utils import yellow
+from timetracker.cfg.utils import get_dirhome_globalcfg
 from timetracker.cfg.cfg_local  import CfgProj
 from timetracker.cfg.cfg_global import CfgGlobal
 from timetracker.msgs import str_init
 
 
-def cli_run_csv(fnamecfg, args):
+def cli_run_projects(fnamecfg, args):
     """Stop the timer and record this time unit"""
-    run_csv(
+    run_projects(
         fnamecfg,
         args.name)
 
-def run_csv(fnamecfg, uname, dirhome=None):
+def run_projects(fnamecfg, uname, dirhome=None):
     """Stop the timer and record this time unit"""
     # Get the starting time, if the timer is running
-    debug(yellow('RUNNING COMMAND CSV'))
+    debug(yellow('RUNNING COMMAND PROJECTS'))
+    dirhome = get_dirhome_globalcfg()
     if not exists(fnamecfg):
         print(str_init(fnamecfg))
     cfgproj = CfgProj(fnamecfg, dirhome=dirhome)
 
     # List location of the timetracker file with this time unit
     if uname == 'all':
-        _get_csv_proj_all(cfgproj)
+        _get_proj_all(cfgproj)
     else:
-        _get_csv_proj_user(cfgproj, uname)
+        _get_proj_user(cfgproj, uname)
 
-def _get_csv_proj_user(cfgproj, uname):
+def _get_proj_user(cfgproj, uname):
     fcsv = cfgproj.get_filename_csv(uname)
     if fcsv is not None:
         print(f'CSV exists({int(exists(fcsv))}) {fcsv}')
 
-def _get_csv_proj_all(cfgproj):
+def _get_proj_all(cfgproj):
     fcsvs = cfgproj.get_project_csvs()
     for fcsv in fcsvs:
         if fcsv is not None:

--- a/timetracker/cmd/start.py
+++ b/timetracker/cmd/start.py
@@ -54,7 +54,7 @@ def run_start(fnamecfg, name=None, **kwargs):
         #cfgproj.mk_workdir()
         #cfgproj.update_localini(project, csvdir)
         #cfgproj.wr_cfg()
-        #cfg_global = CfgGlobal()
+        #cfg_global = CfgGlobal(dirhome)
         #chgd = cfg_global.add_proj(cfgproj.project, cfgproj.get_filename_cfgproj())
         #if chgd:
         #    cfg_global.wr_cfg()

--- a/timetracker/cmd/start.py
+++ b/timetracker/cmd/start.py
@@ -12,7 +12,7 @@ from logging import debug
 ##from timeit import default_timer
 ##$from datetime import timedelta
 from datetime import datetime
-from timetracker.msgs import str_how_to_stop_now
+#from timetracker.msgs import str_how_to_stop_now
 #from timetracker.msgs import str_notrkrepo
 from timetracker.msgs import str_uninitialized
 from timetracker.utils import yellow
@@ -67,9 +67,11 @@ def run_start(fnamecfg, name=None, **kwargs):
                   f"for project '{cfgproj.project}'")
     # Informational message
     elif not force:
-        if start_at is None:
-            print(str_how_to_stop_now())
-        else:
+        ## if start_at is None:
+        ##     print('AAAAAAAAAAAAAAAAAAAAAAAAAAAAaa')
+        ##     print(str_how_to_stop_now())
+        ## else:
+        if start_at is not None:
             print(f'Run `trk start --at {start_at} --force` to force restart')
     return start_obj.filename
 

--- a/timetracker/cmd/stop.py
+++ b/timetracker/cmd/stop.py
@@ -49,10 +49,8 @@ def run_stop(fnamecfg, uname, csvfields, **kwargs):
               f'for project, {cfgproj.project}')
         return {'fcsv':fcsv, 'csvline':None}
     stopat = kwargs.get('stop_at')
-    #print('SSSSSSSSSSSSSSSSSSSSSS', stopat)
     now = kwargs.get('now', datetime.now())
-    dtz = now if stopat is None else get_dtz(stopat, now, kwargs.get('defaultdt', now))
-    #dtz = now if stopat is None else get_dtz(stopat, now, kwargs.get('defaultdt'))
+    dtz = now if stopat is None else get_dtz(stopat, now, kwargs.get('defaultdt'))
     if dtz <= dta:
         error(f'NOT WRITING ELAPSED TIME: starttime({dta}) > stoptime({dtz})')
         return {'fcsv':fcsv, 'csvline':None}

--- a/timetracker/cmd/stop.py
+++ b/timetracker/cmd/stop.py
@@ -49,8 +49,10 @@ def run_stop(fnamecfg, uname, csvfields, **kwargs):
               f'for project, {cfgproj.project}')
         return {'fcsv':fcsv, 'csvline':None}
     stopat = kwargs.get('stop_at')
+    #print('SSSSSSSSSSSSSSSSSSSSSS', stopat)
     now = kwargs.get('now', datetime.now())
     dtz = now if stopat is None else get_dtz(stopat, now, kwargs.get('defaultdt', now))
+    #dtz = now if stopat is None else get_dtz(stopat, now, kwargs.get('defaultdt'))
     if dtz <= dta:
         error(f'NOT WRITING ELAPSED TIME: starttime({dta}) > stoptime({dtz})')
         return {'fcsv':fcsv, 'csvline':None}

--- a/timetracker/cmd/time.py
+++ b/timetracker/cmd/time.py
@@ -30,8 +30,8 @@ def run_time_local(fnamecfg, uname, **kwargs):  #, name=None, force=False, quiet
     fcsv = get_fcsv(fnamecfg, uname, kwargs.get('dirhome'))
     return _rpt_time(fcsv) if fcsv is not None else None
 
-def run_time_global(fnamecfg, uname, **kwargs):  #, name=None, force=False, quiet=False):
-    """Report the total time spent on all projects"""
+#def run_time_global(fnamecfg, uname, **kwargs):  #, name=None, force=False, quiet=False):
+#    """Report the total time spent on all projects"""
 
 def _rpt_time(fcsv):
     ocsv = CsvFile(fcsv)

--- a/timetracker/cmd/time.py
+++ b/timetracker/cmd/time.py
@@ -15,17 +15,23 @@ def cli_run_time(fnamecfg, args):
     if args.input and exists(args.input):
         _rpt_time(args.input)
         return
-    run_time(
+    run_time_local(
         fnamecfg,
         args.name,
         unit=args.unit,
     )
+    #if args.global:
+    #    run_time_global(
+    #    )
 
-def run_time(fnamecfg, uname, **kwargs):  #, name=None, force=False, quiet=False):
+def run_time_local(fnamecfg, uname, **kwargs):  #, name=None, force=False, quiet=False):
     """Report the total time spent on a project"""
     debug(yellow('RUNNING COMMAND TIME'))
     fcsv = get_fcsv(fnamecfg, uname, kwargs.get('dirhome'))
     return _rpt_time(fcsv) if fcsv is not None else None
+
+def run_time_global(fnamecfg, uname, **kwargs):  #, name=None, force=False, quiet=False):
+    """Report the total time spent on all projects"""
 
 def _rpt_time(fcsv):
     ocsv = CsvFile(fcsv)

--- a/timetracker/consts.py
+++ b/timetracker/consts.py
@@ -5,6 +5,7 @@ __author__ = "DV Klopfenstein, PhD"
 
 
 DIRTRK = '.timetracker'
+FILENAME_GLOBALCFG = '.timetrackerconfig'
 DIRCSV = '.'
 FMTTIME = '%H:%M:%S.%f'             # time format, with microseconds (default)
 FMTTIME_HMS = '%H:%M:%S'            # time format, without microseconds

--- a/timetracker/epoch.py
+++ b/timetracker/epoch.py
@@ -14,6 +14,8 @@ __author__ = "DV Klopfenstein, PhD"
 from datetime import datetime
 from datetime import timedelta
 #from logging import debug
+#from re import compile as re_compile
+#from re import IGNORECASE
 from pytimeparse2 import parse as pyt2_parser_secs
 from dateutil.parser import parse as dateutil_parserdt
 from dateutil.parser import ParserError
@@ -23,6 +25,7 @@ from timetracker.consts import FMTDT_H
 #from timetracker.utils import cyan
 from timetracker.utils import orange
 
+#NXM = re_compile(r'^\d+(a|p)m', IGNORECASE)
 
 def str_arg_epoch(dtval=None, dtfmt=None, desc=''):
     """Get instructions on how to specify an epoch"""
@@ -78,13 +81,15 @@ def str_arg_epoch(dtval=None, dtfmt=None, desc=''):
 def get_dtz(elapsed_or_dt, dta, defaultdt=None):
     """Get stop datetime, given a start time and a specific or elapsed time"""
     if elapsed_or_dt.count(':') != 2:
-        #debug(cyan(f'AAAAAAAAAAAAAA Using pytimeparse2({elapsed_or_dt}) + {dta}'))
+        #print(cyan(f'AAAAAAAAAAAAAA Using pytimeparse2({elapsed_or_dt}) + {dta}'))
         secs = _conv_timedelta(elapsed_or_dt)
-        #debug(cyan(f'BBBBBBBBBBBBBB secs = {secs}'))
+        #print(cyan(f'BBBBBBBBBBBBBB secs = {secs}'))
         if secs is not None:
             return dta + timedelta(seconds=secs)
     try:
-        #debug(cyan(f'CCCCCCCCCCCCCC Using dateutil.parser({elapsed_or_dt}, default={defaultdt})'))
+        ##if defaultdt is not None:
+        ##    elapsed_or_dt = _adjust_ampm(elapsed_or_dt)
+        #print(cyan(f'CCCCCCCCCCCCCC Using dateutil.parser({elapsed_or_dt}, default={defaultdt})'))
         return dateutil_parserdt(elapsed_or_dt, default=defaultdt)
     except (ParserError, UnknownTimezoneWarning) as err:
         print(orange(f'ERROR: {err}'))
@@ -97,6 +102,13 @@ def _conv_timedelta(elapsed_or_dt):
     except TypeError as err:
         raise RuntimeError(f'UNABLE TO CONVERT str({elapsed_or_dt}) '
                             'TO A timedelta object') from err
+
+#def _adjust_ampm(elapsed_or_dt):
+#    """Adjust for behavior when defaultdt is not None.
+#
+#       https://github.com/dateutil/dateutil/issues/1421
+#       """
+#       #if (
 
 ####def is_datetime(self):
 ####    """Check if epoch is a datetime, rather than an elapsed time"""

--- a/timetracker/epoch.py
+++ b/timetracker/epoch.py
@@ -103,13 +103,6 @@ def _conv_timedelta(elapsed_or_dt):
         raise RuntimeError(f'UNABLE TO CONVERT str({elapsed_or_dt}) '
                             'TO A timedelta object') from err
 
-#def _adjust_ampm(elapsed_or_dt):
-#    """Adjust for behavior when defaultdt is not None.
-#
-#       https://github.com/dateutil/dateutil/issues/1421
-#       """
-#       #if (
-
 ####def is_datetime(self):
 ####    """Check if epoch is a datetime, rather than an elapsed time"""
 ####    epoch = self.estr

--- a/timetracker/fncs.py
+++ b/timetracker/fncs.py
@@ -6,7 +6,7 @@ __author__ = "DV Klopfenstein, PhD"
 from timetracker.cmd.init      import cli_run_init
 from timetracker.cmd.start     import cli_run_start
 from timetracker.cmd.stop      import cli_run_stop
-from timetracker.cmd.csv       import cli_run_csv
+from timetracker.cmd.projects  import cli_run_projects
 from timetracker.cmd.cancel    import cli_run_cancel
 from timetracker.cmd.time      import cli_run_time
 from timetracker.cmd.report    import cli_run_report
@@ -21,7 +21,7 @@ FNCS = {
     'cancel'   : cli_run_cancel,
     'time'     : cli_run_time,
     'report'   : cli_run_report,
-    'csv'      : cli_run_csv,
+    'projects' : cli_run_projects,
     #'csvloc'   : cli_run_csvloc,
     'csvupdate': cli_run_csvupdate,
 }

--- a/timetracker/msgs.py
+++ b/timetracker/msgs.py
@@ -26,7 +26,7 @@ def str_tostart_epoch():
 def str_how_to_stop_now():
     """Message to print when the timer is started"""
     return ('Run `trk stop -m "task description"` '
-            'to stop tracking now and record this time unit')
+            'to stop tracking now and record this time unit') # str_how_to_stop_now
 
 def str_cancelled1():
     """Message to print when the timer is canceled"""

--- a/timetracker/msgs.py
+++ b/timetracker/msgs.py
@@ -56,7 +56,7 @@ def str_init_empty_proj(cfglocal):
 def str_init(fnamecfg):
     """Message that occurs when there is no Timetracking config file"""
     return ('Run `trk init` to initialize time-tracking '
-           f'for the project in {dirname(fnamecfg)}')
+           f'for the project in {dirname(dirname(fnamecfg))}')
 
 def str_notrkrepo_mount(mountname, trkdir):
     """Message when researcher is not in a dir or subdir that is managed by trk"""

--- a/timetracker/starttime.py
+++ b/timetracker/starttime.py
@@ -86,7 +86,7 @@ class Starttime:
         """Get datetime from a starttime file"""
         return self._read_starttime() if exists(self.filename) else None
 
-    def prt_elapsed(self, msg='Timer running'):
+    def prt_elapsed(self, msg='Timer running;'):
         """Print elapsed time if timer is started"""
         # Print elapsed time, if timer was started
         if exists(self.filename):


### PR DESCRIPTION
* ADD stop --at test
* ADD report command
  * Initial implementation works for a single user on a single project (more to come)
* CHANGED arg, `--trksubdir` to match git's `--git-dir`
* CHANGED CfgGlobal param to the config filename
* CHANGED Fine-tuned stdout messages to researcher for commands: start, stop, and cancel
* CHANGED datetime & timedelta parsing to be simpler
* CHANGED code to use [`pytimeparse2`](https://github.com/onegreyonewhite/pytimeparse2) before `dateutils` to ensure stopping the timer in "4hours" is interpreted as "4hours from now" and not "4am today"
* CHANGED code to adapt to dateutils parse function behavior
* CHANGED to ensure None is written as '' in csv
* CHANGED csv writing code from the stop command to the CsvFile object
