### PR TITLE
Convert free text containing a time and optionally a date 100x faster than with requisite module for explicit use cases

### DIFF
--- a/.timetracker/.gitignore
+++ b/.timetracker/.gitignore
@@ -1,0 +1,1 @@
+start_*.txt

--- a/.timetracker/config
+++ b/.timetracker/config
@@ -1,0 +1,6 @@
+# TimeTracker project configuration file
+
+project = "timetracker"
+
+[csv]
+filename = "./timetracker_timetracker_$USER$.csv"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-# Timetracker-csv
-[![PyPI - Version](https://img.shields.io/pypi/v/timetracker-csv)](https://pypi.org/project/timetracker-csv)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14803225.svg)](https://doi.org/10.5281/zenodo.14803225)
-![GitHub License](https://img.shields.io/github/license/dvklopfenstein/timetracker)
+<p align="center" style="display:inline">
+<h1 align="center">Timetracker-csv</h1>
+<h3 align="center">Pandas-friendly time tracking from the CLI, repo by repo</h3>
+<h3 align="center">
+<img src="https://img.shields.io/pypi/v/timetracker-csv" alt="PyPI - Version"> |
+<img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14803225.svg" alt="DOI"> |
+<img src="https://img.shields.io/github/license/dvklopfenstein/timetracker" alt="License">
+</h3>
+</p>
 
-Track time spent on multiple projects,
+---
+
+* Track time spent on multiple projects,
 one repo at a time from the [CLI](https://blog.iron.io/pros-and-cons-of-a-command-line-interface)    
 
-Time is saved in
+* Time is saved in
 [pandas](https://pandas.pydata.org/pandas-docs/stable/index.html)-friendly
 [CSV](https://www.datarisy.com/blog/understanding-csv-files-use-cases-benefits-and-limitations) files.
 
-CSV files for each project can be combined into a single CSV file for analysis and plotting.
+* CSV files for each project can be combined into a single CSV file for analysis and plotting.
 
 <p align="center"><img src="https://github.com/dvklopfenstein/timetracker/raw/main/doc/mkdocs/source/images/stopwatch.png" alt="timetracker" width="750"/></p>
 

--- a/doc/thirdparty/harvest_import.csv
+++ b/doc/thirdparty/harvest_import.csv
@@ -1,0 +1,3 @@
+"Date","Client","Project","Task","Notes","Hours","First name","Last name"
+2008-08-01,"Iridesco","Harvest","Backend Programming","Recurring invoices",1,"Barry","Hess"
+2008-08-02,"Iridesco","Harvest","Backend Programming","CSV import",1.02,"Barry","Hess"

--- a/tests/pkgtttest/epochcli.py
+++ b/tests/pkgtttest/epochcli.py
@@ -11,7 +11,7 @@ from timetracker.utils import white
 from timetracker.utils import yellow
 
 from timetracker.epoch.cli import run
-from timetracker.epoch.epoch import get_dt_from_td
+from timetracker.epoch.epoch import _get_dt_from_td
 
 
 def main(arglist=None):
@@ -22,7 +22,7 @@ def main(arglist=None):
 
 def get_dateutils_answer(elapsed_or_dt, dta, defaultdt=None):
     """Get stop datetime, given a start time and a specific or elapsed time"""
-    dto = get_dt_from_td(elapsed_or_dt, dta)
+    dto = _get_dt_from_td(elapsed_or_dt, dta)
     if dto is not None:
         return dto
     try:

--- a/tests/pkgtttest/timestrs.py
+++ b/tests/pkgtttest/timestrs.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Free text containing datetimes"""
+
+from datetime import datetime
+
+NOW = datetime.today()
+
+TIMESTRS = {
+    '12am':{
+        'exp_dct':[{'hour': 12, 'AM/PM': 'AM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 0, 0, 0)
+    },
+
+    '12pm':{
+        'exp_dct':[{'hour': 12, 'AM/PM': 'PM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 0, 0)
+    },
+
+    '12:01am':{
+        'exp_dct':[{'hour': 12, 'AM/PM': 'AM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 0, 1, 0)
+    },
+
+    '12:01pm':{
+        'exp_dct':[{'hour': 12, 'AM/PM': 'PM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 1, 0)
+    },
+
+    '5pm':{
+        'exp_dct':[{'hour':5, 'AM/PM':'PM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 17, 0, 0)
+    },
+
+    '5pm 3am':{
+        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
+                   {'hour':3, 'AM/PM':'AM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
+    },
+
+    '5pm a 3am a ':{
+        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
+                   {'hour':3, 'AM/PM':'AM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
+    },
+
+    '5pm xtra txt':{
+        'exp_dct':[{'hour':5, 'AM/PM':'PM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 17, 0, 0),
+    },
+
+    'ampm':{'exp_dct':[], 'dt':None},
+
+    '13:23:00':{
+        'exp_dct':[{'hour':13, 'minute': 23, 'second': 0}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 13, 23, 0),
+    },
+
+    '2025':{
+        'exp_dct':[{'year': 2025}],
+        'dt': None,
+    },
+
+    '2025-06-10 08:57:12 AM':{
+        'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
+                   {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
+        'dt': datetime(2025, 6, 10, 8, 57, 12),
+    },
+
+    '2025-06-10 8:57:12am':{
+        'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
+                   {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
+        'dt': datetime(2025, 6, 10, 8, 57, 12),
+    },
+
+    '13pm':{
+        'exp_dct':[{'hour': 13, 'AM/PM': 'PM'}],
+        'dt': None,
+    },
+}

--- a/tests/pkgtttest/timestrs.py
+++ b/tests/pkgtttest/timestrs.py
@@ -17,8 +17,13 @@ TIMESTRS = {
     },
 
     '12:01am':{
-        'exp_dct':[{'hour': 12, 'AM/PM': 'AM'}],
+        'exp_dct':[{'hour': 12, 'minute':1, 'AM/PM': 'AM'}],
         'dt': datetime(NOW.year, NOW.month, NOW.day, 0, 1, 0)
+    },
+
+    '12:15:30am':{
+        'exp_dct':[{'hour': 12, 'minute':15, 'second':30, 'AM/PM': 'AM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 0, 15, 30)
     },
 
     '12:01pm':{
@@ -26,29 +31,15 @@ TIMESTRS = {
         'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 1, 0)
     },
 
+    '12:45:15pm':{
+        'exp_dct':[{'hour': 12, 'AM/PM': 'PM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 45, 15)
+    },
+
     '5pm':{
         'exp_dct':[{'hour':5, 'AM/PM':'PM'}],
         'dt': datetime(NOW.year, NOW.month, NOW.day, 17, 0, 0)
     },
-
-    '5pm 3am':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
-                   {'hour':3, 'AM/PM':'AM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
-    },
-
-    '5pm a 3am a ':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
-                   {'hour':3, 'AM/PM':'AM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
-    },
-
-    '5pm xtra txt':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 17, 0, 0),
-    },
-
-    'ampm':{'exp_dct':[], 'dt':None},
 
     '13:23:00':{
         'exp_dct':[{'hour':13, 'minute': 23, 'second': 0}],
@@ -66,6 +57,24 @@ TIMESTRS = {
         'dt': datetime(2025, 6, 10, 8, 57, 12),
     },
 
+    #'06-10 08:57:12 AM':{
+    #    'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
+    #               {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
+    #    'dt': datetime(2025, 6, 10, 8, 57, 12),
+    #},
+
+    #'6-10 08:57:12 AM':{
+    #    'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
+    #               {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
+    #    'dt': datetime(2025, 6, 10, 8, 57, 12),
+    #},
+
+    #'2025-06-10':{
+    #    'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
+    #               {'hour': NOW.hour, 'minute': NOW.minute, 'second': NOW.second}],
+    #    'dt': datetime(2025, 6, 10, NOW.hour, NOW.minute, NOW.second),
+    #},
+
     '2025-06-10 8:57:12am':{
         'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
                    {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
@@ -76,4 +85,23 @@ TIMESTRS = {
         'exp_dct':[{'hour': 13, 'AM/PM': 'PM'}],
         'dt': None,
     },
+
+    '5pm 3am':{
+        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
+                   {'hour':3, 'AM/PM':'AM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
+    },
+
+    '5pm a 3am a ':{
+        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
+                   {'hour':3, 'AM/PM':'AM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
+    },
+    '5pm xtra txt':{
+        'exp_dct':[{'hour':5, 'AM/PM':'PM'}],
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 17, 0, 0),
+    },
+
+    'ampm':{'exp_dct':[], 'dt':None},
+
 }

--- a/tests/pkgtttest/timestrs.py
+++ b/tests/pkgtttest/timestrs.py
@@ -6,102 +6,157 @@ from datetime import datetime
 NOW = datetime.today()
 
 TIMESTRS = {
+    # ========================================================
+    # ========================================================
     '12am':{
-        'exp_dct':[{'hour': 12, 'AM/PM': 'AM'}],
+        'exp_dct':{'hour': 0},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 0, 0, 0)
     },
 
-    '12pm':{
-        'exp_dct':[{'hour': 12, 'AM/PM': 'PM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 0, 0)
-    },
-
     '12:01am':{
-        'exp_dct':[{'hour': 12, 'minute':1, 'AM/PM': 'AM'}],
+        'exp_dct':{'hour': 0, 'minute':1},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 0, 1, 0)
     },
 
     '12:15:30am':{
-        'exp_dct':[{'hour': 12, 'minute':15, 'second':30, 'AM/PM': 'AM'}],
+        'exp_dct':{'hour': 0, 'minute':15, 'second':30},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 0, 15, 30)
     },
 
+    # --------------------------------------------------------
+    '12pm':{
+        'exp_dct':{'hour': 12},
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 0, 0)
+    },
+
     '12:01pm':{
-        'exp_dct':[{'hour': 12, 'AM/PM': 'PM'}],
+        'exp_dct':{'hour': 12, 'minute':1},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 1, 0)
     },
 
     '12:45:15pm':{
-        'exp_dct':[{'hour': 12, 'AM/PM': 'PM'}],
+        'exp_dct':{'hour': 12, 'minute':45, 'second':15},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 45, 15)
     },
 
+    # --------------------------------------------------------
+    '12':{
+        'exp_dct':{'hour': 12},
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 0, 0)
+    },
+
+    '12:01':{
+        'exp_dct':{'hour': 12, 'minute':1},
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 1, 0)
+    },
+
+    '12:15:30':{
+        'exp_dct':{'hour': 12, 'minute':15, 'second':30},
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 15, 30)
+    },
+
+    # --------------------------------------------------------
+    '13':{
+        'exp_dct':{'hour': 13},
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 13, 0, 0)
+    },
+
+    '13:01':{
+        'exp_dct':{'hour': 13, 'minute':1},
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 13, 1, 0)
+    },
+
+    '13:45:15':{
+        'exp_dct':{'hour': 13, 'minute':45, 'second':15},
+        'dt': datetime(NOW.year, NOW.month, NOW.day, 13, 45, 15)
+    },
+
+    # ========================================================
+    # ========================================================
+    '2025-01-02 12am':{
+        'exp_dct':{'year': 2025, 'month': 1, 'day': 2, 'hour': 0},
+        'dt': datetime(2025, 1, 2, 0, 0, 0)
+    },
+
+    '01-02 12:01am':{
+        'exp_dct':{'month': 1, 'day': 2, 'hour': 0, 'minute':1},
+        'dt': datetime(NOW.year, 1, 2, 0, 1, 0)
+    },
+
+    '1/2 12:01am':{
+        'exp_dct':{'month': 1, 'day': 2, 'hour': 0, 'minute':1},
+        'dt': datetime(NOW.year, 1, 2, 0, 1, 0)
+    },
+
+    '13/2 12:01am':{
+        'exp_dct':None,
+        'dt': None
+    },
+
     '5pm':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'}],
+        'exp_dct':{'hour':17},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 17, 0, 0)
     },
 
     '13:23:00':{
-        'exp_dct':[{'hour':13, 'minute': 23, 'second': 0}],
+        'exp_dct':{'hour':13, 'minute': 23, 'second': 0},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 13, 23, 0),
     },
 
     '2025':{
-        'exp_dct':[{'year': 2025}],
+        'exp_dct': None,
         'dt': None,
     },
 
     '2025-06-10 08:57:12 AM':{
-        'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
-                   {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
+        'exp_dct':{'year': 2025, 'month': 6, 'day': 10,
+                   'hour': 8, 'minute': 57, 'second': 12},
         'dt': datetime(2025, 6, 10, 8, 57, 12),
     },
 
-    #'06-10 08:57:12 AM':{
-    #    'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
-    #               {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
-    #    'dt': datetime(2025, 6, 10, 8, 57, 12),
-    #},
+    # ========================================================
+    # ========================================================
+    '06-10 08:57:12 AM':{
+        'exp_dct':{'month': 6, 'day': 10,
+                   'hour': 8, 'minute': 57, 'second': 12},
+        'dt': datetime(2025, 6, 10, 8, 57, 12),
+    },
 
-    #'6-10 08:57:12 AM':{
-    #    'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
-    #               {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
-    #    'dt': datetime(2025, 6, 10, 8, 57, 12),
-    #},
+    '6-10 08:57:12 AM':{
+        'exp_dct':{'month': 6, 'day': 10,
+                   'hour': 8, 'minute': 57, 'second': 12},
+        'dt': datetime(2025, 6, 10, 8, 57, 12),
+    },
 
-    #'2025-06-10':{
-    #    'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
-    #               {'hour': NOW.hour, 'minute': NOW.minute, 'second': NOW.second}],
-    #    'dt': datetime(2025, 6, 10, NOW.hour, NOW.minute, NOW.second),
-    #},
+    # timetracker-csv requires a value for an hour
+    '2025-06-10':{'exp_dct': None, 'dt': None},
 
     '2025-06-10 8:57:12am':{
-        'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
-                   {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
+        'exp_dct':{'year': 2025, 'month': 6, 'day': 10,
+                   'hour': 8, 'minute': 57, 'second': 12},
         'dt': datetime(2025, 6, 10, 8, 57, 12),
     },
 
+    # ========================================================
     '13pm':{
-        'exp_dct':[{'hour': 13, 'AM/PM': 'PM'}],
+        'exp_dct': None,
         'dt': None,
     },
 
     '5pm 3am':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
-                   {'hour':3, 'AM/PM':'AM'}],
+        'exp_dct':{'hour':3},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
     },
 
     '5pm a 3am a ':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
-                   {'hour':3, 'AM/PM':'AM'}],
+        'exp_dct':{'hour':3},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
     },
     '5pm xtra txt':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'}],
+        'exp_dct':{'hour':17},
         'dt': datetime(NOW.year, NOW.month, NOW.day, 17, 0, 0),
     },
 
-    'ampm':{'exp_dct':[], 'dt':None},
+    'ampm':{'exp_dct':None, 'dt':None},
 
 }

--- a/tests/test_stmch.py
+++ b/tests/test_stmch.py
@@ -5,11 +5,12 @@ from datetime import timedelta
 from timeit import default_timer
 from timetracker.utils import white
 from timetracker.epoch.stmach import _SmHhSsAm
+from timetracker.epoch.stmach import search_texttime
 from timetracker.epoch.epoch import _get_dt_ampm
 from tests.pkgtttest.timestrs import TIMESTRS
 
 
-def test_ampm():
+def test_txt_to_dt():
     """Test state machines used for finding 'am', 'pm', 'AM', or 'PM' in free text"""
     for txt, dct in TIMESTRS.items():
         #_run_ampm(txt, dct['exp_dct'])
@@ -17,6 +18,17 @@ def test_ampm():
         assert act == dct['dt'], ('EXP != ACT:\n'
             f'  TXT: {txt}\n'
             f'  EXP: {dct["dt"]}\n'
+            f'  ACT: {act}\n')
+        print(f'{act} <- {txt}\n')
+
+def test_txt_to_dct():
+    """Test state machines used for finding 'am', 'pm', 'AM', or 'PM' in free text"""
+    for txt, dct in TIMESTRS.items():
+        #_run_ampm(txt, dct['exp_dct'])
+        act = search_texttime(txt)
+        assert act == dct['exp_dct'], ('EXP != ACT:\n'
+            f'  TXT: {txt}\n'
+            f'  EXP: {dct["exp_dct"]}\n'
             f'  ACT: {act}\n')
         print(f'{act} <- {txt}\n')
 
@@ -47,5 +59,6 @@ def _search_for_ampm(txt):
 
 if __name__ == '__main__':
     tic_all = default_timer()
-    test_ampm()
+    test_txt_to_dt()
+    test_txt_to_dct()
     print(white(f'{timedelta(seconds=default_timer()-tic_all)} TOTAL TIME FOR ALL TESTS'))

--- a/tests/test_stmch.py
+++ b/tests/test_stmch.py
@@ -1,93 +1,19 @@
 #!/usr/bin/env python3
-"""Test state machines used for finding datetime in free text"""
+"""Test converting free text to datetimes"""
 
-from datetime import datetime
 from datetime import timedelta
 from timeit import default_timer
 from timetracker.utils import white
 from timetracker.epoch.stmach import _SmHhSsAm
-from timetracker.epoch.epoch import get_dt_ampm
+from timetracker.epoch.epoch import _get_dt_ampm
+from tests.pkgtttest.timestrs import TIMESTRS
 
-NOW = datetime.today()
-
-TESTIO = {
-    '12am':{
-        'exp_dct':[{'hour': 12, 'AM/PM': 'AM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 0, 0, 0)
-    },
-
-    '12pm':{
-        'exp_dct':[{'hour': 12, 'AM/PM': 'PM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 0, 0)
-    },
-
-    '12:01am':{
-        'exp_dct':[{'hour': 12, 'AM/PM': 'AM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 0, 1, 0)
-    },
-
-    '12:01pm':{
-        'exp_dct':[{'hour': 12, 'AM/PM': 'PM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 12, 1, 0)
-    },
-
-    '13pm':{
-        'exp_dct':[{'hour': 13, 'AM/PM': 'PM'}],
-        'dt': None,
-    },
-
-    '5pm':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 17, 0, 0)
-    },
-
-    '5pm 3am':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
-                   {'hour':3, 'AM/PM':'AM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
-    },
-
-    '5pm a 3am a ':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'},
-                   {'hour':3, 'AM/PM':'AM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 3, 0, 0),
-    },
-
-    '5pm xtra txt':{
-        'exp_dct':[{'hour':5, 'AM/PM':'PM'}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 17, 0, 0),
-    },
-
-    'ampm':{'exp_dct':[], 'dt':None},
-
-    '13:23:00':{
-        'exp_dct':[{'hour':13, 'minute': 23, 'second': 0}],
-        'dt': datetime(NOW.year, NOW.month, NOW.day, 13, 23, 0),
-    },
-
-    '2025':{
-        'exp_dct':[{'year': 2025}],
-        'dt': None,
-    },
-
-    '2025-06-10 08:57:12 AM':{
-        'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
-                   {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
-        'dt': datetime(2025, 6, 10, 8, 57, 12),
-    },
-
-    '2025-06-10 8:57:12am':{
-        'exp_dct':[{'year': 2025, 'month': 6, 'day': 10},
-                   {'hour': 8, 'minute': 57, 'second': 12, 'AM/PM':'AM'}],
-        'dt': datetime(2025, 6, 10, 8, 57, 12),
-    },
-}
 
 def test_ampm():
     """Test state machines used for finding 'am', 'pm', 'AM', or 'PM' in free text"""
-    for txt, dct in TESTIO.items():
+    for txt, dct in TIMESTRS.items():
         #_run_ampm(txt, dct['exp_dct'])
-        act = get_dt_ampm(txt, None)
+        act = _get_dt_ampm(txt, None)
         assert act == dct['dt'], ('EXP != ACT:\n'
             f'  TXT: {txt}\n'
             f'  EXP: {dct["dt"]}\n'

--- a/tests/test_tt_getdt.py
+++ b/tests/test_tt_getdt.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Test various methods for converting free text to a timestring"""
+
+from datetime import timedelta
+from timeit import default_timer
+from timetracker.epoch.epoch import _get_dt_ampm
+from timetracker.epoch.epoch import _conv_timedelta
+from timetracker.epoch.epoch import _conv_datetime
+from tests.pkgtttest.timestrs import TIMESTRS
+from tests.pkgtttest.timestrs import NOW
+
+
+def test_tt_getdt():
+    """Test various methods for converting free text to a timestring"""
+    print(f'NOW: {NOW}')
+    for timestr, expdct in TIMESTRS.items():
+        print(f'\nTIMESTR({timestr})')
+
+        tic = default_timer()
+        dta = _get_dt_ampm(timestr, NOW)
+        assert dta == expdct['dt']
+        tta = timedelta(seconds=default_timer()-tic)
+        print(f'{tta}    _get_dt_ampm({timestr}) {dta}')
+
+        tic = default_timer()
+        dtb = _conv_datetime(timestr, NOW)
+        ttb = timedelta(seconds=default_timer()-tic)
+        print(f'{ttb}  _conv_datetime({timestr}) {dtb}')
+
+        tic = default_timer()
+        dtc = _conv_timedelta(timestr)
+        ttc = timedelta(seconds=default_timer()-tic)
+        print(f'{ttc} _conv_timedelta({timestr}) {dtc}')
+
+        if dta is not None and dtb is not None:
+            assert dta == dtb
+
+
+if __name__ == '__main__':
+    test_tt_getdt()

--- a/tests/test_tt_getdt.py
+++ b/tests/test_tt_getdt.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 """Test various methods for converting free text to a timestring"""
 
+from collections import namedtuple
 from datetime import timedelta
+from csv import writer
 from timeit import default_timer
+from re import compile as re_compile
+
 from timetracker.epoch.epoch import _get_dt_ampm
 from timetracker.epoch.epoch import _conv_timedelta
 from timetracker.epoch.epoch import _conv_datetime
@@ -10,11 +14,28 @@ from tests.pkgtttest.timestrs import TIMESTRS
 from tests.pkgtttest.timestrs import NOW
 
 
-def test_tt_getdt():
+def test_tt_getdt(fcsv='timetrials_datatime.csv'):
     """Test various methods for converting free text to a timestring"""
+    nto = namedtuple('RunTimes', 'DVK DVK_matched dateparser dateparser_matched txt')
+    timedata = _run(nto)
+    #_prt_timedata(timedata)
+    _wr_timedata(fcsv, timedata, nto)
+
+
+def _run(nto):
+    timedata = []
+    #cmp_time = re_compile(r'((\d{1,2}):){0,2}(\d{1,2})\s*(?P<AM_PM>[aApP][mM])')
+    # pylint: disable=line-too-long
+    cmp_time = re_compile(r'((?P<hour>\d{1,2})[^-/_](:(?P<minute>\d{1,2}))?[^-/_](:(?P<second>\d{1,2}))?\s*(?P<AM_PM>[aApP][mM])?)')
+    cmp_date = re_compile(r'((?P<year>\d{4})[-/_]?)?(?P<month>\d{1,2})[-/_](?P<day>\d{1,2})')
     print(f'NOW: {NOW}')
     for timestr, expdct in TIMESTRS.items():
         print(f'\nTIMESTR({timestr})')
+        tic = default_timer()
+        print("SEARCH FOR TIME:", cmp_time.search(timestr))
+        print("SEARCH FOR DATE:", cmp_date.search(timestr))
+        tt0 = timedelta(seconds=default_timer()-tic)
+        print(f'{tt0}    re          ({timestr})')  # {dta}')
 
         tic = default_timer()
         dta = _get_dt_ampm(timestr, NOW)
@@ -25,7 +46,7 @@ def test_tt_getdt():
         tic = default_timer()
         dtb = _conv_datetime(timestr, NOW)
         ttb = timedelta(seconds=default_timer()-tic)
-        print(f'{ttb}  _conv_datetime({timestr}) {dtb}')
+        #print(f'{ttb}  _conv_datetime({timestr}) {dtb}')
 
         tic = default_timer()
         dtc = _conv_timedelta(timestr)
@@ -40,6 +61,24 @@ def test_tt_getdt():
             if timestr not in {'12', '13'}:
                 assert dta == dtb, f'DVK != DTP\nTXT({timestr})\nDVK({dta})\nDTP({dtb})'
 
+        timedata.append(nto(
+            txt=timestr,
+            DVK        =tta.total_seconds()*1_000_000,        DVK_matched=dta is not None,
+            dateparser =ttb.total_seconds()*1_000_000, dateparser_matched=dtb is not None))
+
+    return timedata
+
+def _prt_timedata(timedata):
+    for ntd in timedata:
+        print(ntd)
+
+def _wr_timedata(fcsv, timedata, nto):
+    with open(fcsv, 'w', encoding='utf-8') as ostrm:
+        wrobj = writer(ostrm)
+        wrobj.writerow(nto._fields)
+        for ntd in timedata:
+            wrobj.writerow(ntd)
+        print(f'  WROTE: {fcsv}')
 
 if __name__ == '__main__':
     test_tt_getdt()

--- a/tests/test_tt_getdt.py
+++ b/tests/test_tt_getdt.py
@@ -32,11 +32,13 @@ def test_tt_getdt():
         ttc = timedelta(seconds=default_timer()-tic)
         print(f'{ttc} _conv_timedelta({timestr}) {dtc}')
 
-        perc_faster = ttb.total_seconds()/tta.total_seconds()
-        print(f'{perc_faster:10.1f} times faster is trk alg compared to dateparser for use case({timestr})')
+        faster = ttb.total_seconds()/tta.total_seconds()
+        print(f'{faster:10.1f} times faster is trk alg compared to dateparser for "{timestr}"')
 
         if dta is not None and dtb is not None:
-            assert dta == dtb, f'ACT != EXP\nTXT({timestr})\nACT({dta})\nEXP({dtb})'
+            # dateparser considers a number a month, DVK considers it an hour
+            if timestr not in {'12', '13'}:
+                assert dta == dtb, f'DVK != DTP\nTXT({timestr})\nDVK({dta})\nDTP({dtb})'
 
 
 if __name__ == '__main__':

--- a/tests/test_tt_getdt.py
+++ b/tests/test_tt_getdt.py
@@ -32,6 +32,9 @@ def test_tt_getdt():
         ttc = timedelta(seconds=default_timer()-tic)
         print(f'{ttc} _conv_timedelta({timestr}) {dtc}')
 
+        perc_faster = ttb.total_seconds()/tta.total_seconds()
+        print(f'{perc_faster:10.1f} times faster is trk alg compared to dateparser for use case({timestr})')
+
         if dta is not None and dtb is not None:
             assert dta == dtb, f'ACT != EXP\nTXT({timestr})\nACT({dta})\nEXP({dtb})'
 

--- a/tests/test_tt_getdt.py
+++ b/tests/test_tt_getdt.py
@@ -18,7 +18,7 @@ def test_tt_getdt():
 
         tic = default_timer()
         dta = _get_dt_ampm(timestr, NOW)
-        assert dta == expdct['dt']
+        assert dta == expdct['dt'], f'ACT != EXP\nTXT({timestr})\nACT({dta})\nEXP({expdct["dt"]})'
         tta = timedelta(seconds=default_timer()-tic)
         print(f'{tta}    _get_dt_ampm({timestr}) {dta}')
 
@@ -33,7 +33,7 @@ def test_tt_getdt():
         print(f'{ttc} _conv_timedelta({timestr}) {dtc}')
 
         if dta is not None and dtb is not None:
-            assert dta == dtb
+            assert dta == dtb, f'ACT != EXP\nTXT({timestr})\nACT({dta})\nEXP({dtb})'
 
 
 if __name__ == '__main__':

--- a/timetracker/epoch/epoch.py
+++ b/timetracker/epoch/epoch.py
@@ -86,33 +86,32 @@ def get_dtz(elapsed_or_dt, dta, defaultdt=None):
 def _conv_datetime(timestr, defaultdt):
     try:
         settings = None if defaultdt is None else {'RELATIVE_BASE': defaultdt}
-        ##tic = default_timer()
+        ##tic = default_timer()  # PRT
         dto = dateparser_parserdt(timestr, settings=settings)
-        ##print(f'{timedelta(seconds=default_timer()-tic)} dateparser   parse({timestr})')
-        ##if dto is None:
-        ##    print(f'ERROR: text({timestr}) could not be converted to a datetime object')
+        ##print(f'{timedelta(seconds=default_timer()-tic)} dateparser   parse({timestr})')  # PRT
+        ##if dto is None:  # PRT
+        ##    print(f'ERROR: text({timestr}) could not be converted to a datetime object')  # PRT
         return dto
     except (ValueError, TypeError, SettingValidationError) as err:
         print(f'ERROR FROM python-dateparser: {err}')
     print(f'"{timestr}" COULD NOT BE CONVERTED TO A DATETIME BY dateparsers')
     return None
 
-
 def _get_dt_ampm(elapsed_or_dt, defaultdt):
     """Get a datetime object from free text that contains AM/PM"""
-    ##tic = default_timer()
-    ##print(f'TEXT({elapsed_or_dt})')
+    ##tic = default_timer()  # PRT
+    ##print(f'TEXT({elapsed_or_dt})')  # PRT
     ret = None
     if (mtch := search_texttime(elapsed_or_dt)) is not None and 'hour' in mtch:
-        ##print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) SM')
+        ##print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) SM')  # PRT
         _get_ymd(mtch, defaultdt)
-        ##print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) today()')
+        ##print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) today()')  # PRT
         ret = datetime(year=mtch['year'], month=mtch['month'], day=mtch['day'],
                        hour=mtch['hour'],
                        minute=mtch.get('minute', 0),
                        second=mtch.get('second', 0))
-        ##print(f'DEFAULTDT: {today} {ret}')
-    ##print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) new datetime')
+        ##print(f'DEFAULTDT: {today} {ret}')  # PRT
+    ##print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) new datetime')  # PRT
     return ret
 
 def _get_ymd(mtch, defaultdt):
@@ -134,13 +133,12 @@ def _get_dt_from_td(elapsed_or_dt, dta):
 
 def _conv_timedelta(elapsed_or_dt):
     try:
-        ##tic = default_timer()
+        ##tic = default_timer()  # PRT
         ret = pyt2_parse_secs(elapsed_or_dt)
-        ##print(f'{timedelta(seconds=default_timer()-tic)} pytimeparse2 parse({elapsed_or_dt})')
+        ##print(f'{timedelta(seconds=default_timer()-tic)} pytimeparse2 parse({elapsed_or_dt})')  # PRT
         return ret
     except TypeError as err:
         raise RuntimeError(f'UNABLE TO CONVERT str({elapsed_or_dt}) '
                             'TO A timedelta object') from err
-
 
 # Copyright (C) 2025-present, DV Klopfenstein, PhD. All rights reserved.

--- a/timetracker/epoch/epoch.py
+++ b/timetracker/epoch/epoch.py
@@ -77,24 +77,28 @@ def get_now():
 
 def get_dtz(elapsed_or_dt, dta, defaultdt=None):
     """Get stop datetime, given a start time and a specific or elapsed time"""
-    ##if (dto := get_dt_ampm(elapsed_or_dt, defaultdt)) is not None:
+    ##if (dto := _get_dt_ampm(elapsed_or_dt, defaultdt)) is not None:
     ##    return dto
-    if (dto := get_dt_from_td(elapsed_or_dt, dta)) is not None:
+    if (dto := _get_dt_from_td(elapsed_or_dt, dta)) is not None:
         return dto
+    return _conv_datetime(elapsed_or_dt, defaultdt)
+
+def _conv_datetime(timestr, defaultdt):
     try:
         settings = None if defaultdt is None else {'RELATIVE_BASE': defaultdt}
         ##tic = default_timer()
-        dto = dateparser_parserdt(elapsed_or_dt, settings=settings)
-        ##print(f'{timedelta(seconds=default_timer()-tic)} dateparser   parse({elapsed_or_dt})')
+        dto = dateparser_parserdt(timestr, settings=settings)
+        ##print(f'{timedelta(seconds=default_timer()-tic)} dateparser   parse({timestr})')
         ##if dto is None:
-        ##    print(f'ERROR: text({elapsed_or_dt}) could not be converted to a datetime object')
+        ##    print(f'ERROR: text({timestr}) could not be converted to a datetime object')
         return dto
     except (ValueError, TypeError, SettingValidationError) as err:
         print(f'ERROR FROM python-dateparser: {err}')
-    print(f'"{elapsed_or_dt}" COULD NOT BE CONVERTED TO A DATETIME BY dateparsers')
+    print(f'"{timestr}" COULD NOT BE CONVERTED TO A DATETIME BY dateparsers')
     return None
 
-def get_dt_ampm(elapsed_or_dt, defaultdt):
+
+def _get_dt_ampm(elapsed_or_dt, defaultdt):
     """Get a datetime object from free text that contains AM/PM"""
     ##tic = default_timer()
     ##print(f'TEXT({elapsed_or_dt})')
@@ -120,7 +124,7 @@ def _get_ymd(mtch, defaultdt):
     mtch['month'] = today.month
     mtch['day']   = today.day
 
-def get_dt_from_td(elapsed_or_dt, dta):
+def _get_dt_from_td(elapsed_or_dt, dta):
     """Get a datetime object from a timedelta time string"""
     if elapsed_or_dt.count(':') != 2 and (secs := _conv_timedelta(elapsed_or_dt)):
         return dta + timedelta(seconds=secs)

--- a/timetracker/epoch/epoch.py
+++ b/timetracker/epoch/epoch.py
@@ -14,7 +14,7 @@ __author__ = "DV Klopfenstein, PhD"
 from datetime import datetime
 from datetime import date
 from datetime import timedelta
-##from timeit import default_timer
+#from timeit import default_timer  # PRT
 from pytimeparse2 import parse as pyt2_parse_secs
 from dateparser import parse as dateparser_parserdt
 from dateparser.conf import SettingValidationError
@@ -77,8 +77,9 @@ def get_now():
 
 def get_dtz(elapsed_or_dt, dta, defaultdt=None):
     """Get stop datetime, given a start time and a specific or elapsed time"""
-    ##if (dto := _get_dt_ampm(elapsed_or_dt, defaultdt)) is not None:
-    ##    return dto
+#    _get_dt_ampm(elapsed_or_dt, defaultdt)  # PRT
+    if (dto := _get_dt_ampm(elapsed_or_dt, defaultdt)) is not None:
+        return dto
     if (dto := _get_dt_from_td(elapsed_or_dt, dta)) is not None:
         return dto
     return _conv_datetime(elapsed_or_dt, defaultdt)
@@ -86,11 +87,11 @@ def get_dtz(elapsed_or_dt, dta, defaultdt=None):
 def _conv_datetime(timestr, defaultdt):
     try:
         settings = None if defaultdt is None else {'RELATIVE_BASE': defaultdt}
-        ##tic = default_timer()  # PRT
+#        tic = default_timer()  # PRT
         dto = dateparser_parserdt(timestr, settings=settings)
-        ##print(f'{timedelta(seconds=default_timer()-tic)} dateparser   parse({timestr})')  # PRT
-        ##if dto is None:  # PRT
-        ##    print(f'ERROR: text({timestr}) could not be converted to a datetime object')  # PRT
+#        print(f'{timedelta(seconds=default_timer()-tic)} dateparser   parse({timestr})')  # PRT
+#        if dto is None:  # PRT
+#            print(f'ERROR: text({timestr}) could not be converted to a datetime object')  # PRT
         return dto
     except (ValueError, TypeError, SettingValidationError) as err:
         print(f'ERROR FROM python-dateparser: {err}')
@@ -99,25 +100,25 @@ def _conv_datetime(timestr, defaultdt):
 
 def _get_dt_ampm(elapsed_or_dt, defaultdt):
     """Get a datetime object from free text that contains AM/PM"""
-    ##tic = default_timer()  # PRT
-    ##print(f'TEXT({elapsed_or_dt})')  # PRT
+#    tic = default_timer()  # PRT
+#    print(f'TEXT({elapsed_or_dt})')  # PRT
     ret = None
     if (mtch := search_texttime(elapsed_or_dt)) is not None and 'hour' in mtch:
-        ##print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) SM')  # PRT
+#        print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) SM')  # PRT
         _get_ymd(mtch, defaultdt)
-        ##print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) today()')  # PRT
+#        print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) today()')  # PRT
         ret = datetime(year=mtch['year'], month=mtch['month'], day=mtch['day'],
                        hour=mtch['hour'],
                        minute=mtch.get('minute', 0),
                        second=mtch.get('second', 0))
-        ##print(f'DEFAULTDT: {today} {ret}')  # PRT
-    ##print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) new datetime')  # PRT
+#    print(f'{timedelta(seconds=default_timer()-tic)} parse({elapsed_or_dt}) new datetime')  # PRT
     return ret
 
 def _get_ymd(mtch, defaultdt):
     if {'year', 'month', 'day'}.issubset(set(mtch.keys())):
         return
     today = date.today() if defaultdt is None else defaultdt
+#    print(f'DEFAULTDT: {today}')  # PRT
     if 'year' not in mtch:
         mtch['year']  = today.year
     if 'month' not in mtch:
@@ -131,14 +132,14 @@ def _get_dt_from_td(elapsed_or_dt, dta):
         return dta + timedelta(seconds=secs)
     return None
 
-def _conv_timedelta(elapsed_or_dt):
+def _conv_timedelta(timestr):
     try:
-        ##tic = default_timer()  # PRT
-        ret = pyt2_parse_secs(elapsed_or_dt)
-        ##print(f'{timedelta(seconds=default_timer()-tic)} pytimeparse2 parse({elapsed_or_dt})')  # PRT
+#        tic = default_timer()  # PRT
+        ret = pyt2_parse_secs(timestr)
+#        print(f'{timedelta(seconds=default_timer()-tic)} pytimeparse2 parse({timestr})')  # PRT
         return ret
     except TypeError as err:
-        raise RuntimeError(f'UNABLE TO CONVERT str({elapsed_or_dt}) '
+        raise RuntimeError(f'UNABLE TO CONVERT str({timestr}) '
                             'TO A timedelta object') from err
 
 # Copyright (C) 2025-present, DV Klopfenstein, PhD. All rights reserved.

--- a/timetracker/epoch/epoch.py
+++ b/timetracker/epoch/epoch.py
@@ -116,13 +116,15 @@ def _get_dt_ampm(elapsed_or_dt, defaultdt):
     return ret
 
 def _get_ymd(mtch, defaultdt):
-    # If 'year' is in match, than 'month' and 'day' are also in match
-    if 'year' in mtch:
+    if {'year', 'month', 'day'}.issubset(set(mtch.keys())):
         return
     today = date.today() if defaultdt is None else defaultdt
-    mtch['year']  = today.year
-    mtch['month'] = today.month
-    mtch['day']   = today.day
+    if 'year' not in mtch:
+        mtch['year']  = today.year
+    if 'month' not in mtch:
+        mtch['month'] = today.month
+    if 'day' not in mtch:
+        mtch['day']   = today.day
 
 def _get_dt_from_td(elapsed_or_dt, dta):
     """Get a datetime object from a timedelta time string"""

--- a/timetracker/epoch/stmach.py
+++ b/timetracker/epoch/stmach.py
@@ -78,11 +78,11 @@ class _SmHhSsAm:
         val = int(''.join(self.work))
         # Process non-digit
         if letter == ':':
-            return self._run_hour_month('hour', val, 'minute', 23)
+            return self._run_hour_month(val, 'hour', 0, 23, 'minute')
         if letter in {'-', '/', '_'}:
-            return self._run_hour_month('month', val, 'day', 12)
+            return self._run_hour_month(val, 'month', 1, 12, 'day')
         nxt = self._run_ap(letter)
-        return self._run_hour_month('hour', val, nxt, 23)
+        return self._run_hour_month(val, 'hour', 0, 23, nxt)
 
     def _dfa_min(self, letter):
         if self._run_onetwodigit(letter):
@@ -109,15 +109,6 @@ class _SmHhSsAm:
                 return 'start'
         # Process non-digit
         return self._run_ap(letter)
-
-    def _run_ap(self, letter):
-        if letter in {'a', 'A', 'p', 'P', ' '}:
-            if letter != ' ':
-                self.work = letter.upper()
-            else:
-                self.work = None
-            return 'AM/PM'
-        return 'start'
 
     def _dfa_ampm(self, letter):
         if letter in {'m', 'M'} and self.work:
@@ -155,8 +146,18 @@ class _SmHhSsAm:
             self.stnum = None
         return 'start'
 
-    def _run_hour_month(self, capture_key, capture_val, nxt, max_val):
-        if capture_val <= max_val:
+    def _run_ap(self, letter):
+        if letter in {'a', 'A', 'p', 'P', ' '}:
+            if letter != ' ':
+                self.work = letter.upper()
+            else:
+                self.work = None
+            return 'AM/PM'
+        return 'start'
+
+    def _run_hour_month(self, capture_val, capture_key, min_val, max_val, nxt):
+        # pylint: disable=too-many-arguments
+        if min_val <= capture_val <= max_val:
             self.capture[capture_key] = capture_val
             self.stnum = None
             return nxt

--- a/timetracker/epoch/stmach.py
+++ b/timetracker/epoch/stmach.py
@@ -158,7 +158,7 @@ class _SmHhSsAm:
         return 'start'
 
     def _run_hour_month(self, capture_val, capture_key, min_val, max_val, nxt):
-        # pylint: disable=too-many-arguments
+        # pylint: disable=unknown-option-value,too-many-arguments,too-many-positional-arguments
         if min_val <= capture_val <= max_val:
             self.capture[capture_key] = capture_val
             self.stnum = None

--- a/timetracker/epoch/stmach.py
+++ b/timetracker/epoch/stmach.py
@@ -7,9 +7,32 @@ __author__ = "DV Klopfenstein, PhD"
 # 24:00 refers to midnight at the end of a given date
 # 00:00 refers to the beginning of the day
 
+#from enum import Enum
+#from enum import auto
 ##from timetracker.epoch.sm_ampm import run_ampm
 ##from timetracker.epoch.sm_ampm import get_match_ampm
 ##from timetracker.epoch.sm_ampm import FOUND_AMPM
+
+#class TimePart(Enum):
+#    """Use enums for dfa names"""
+#    START  = auto()
+#    DIGITS = auto()
+#    MINUTE = auto()
+#    SECOND = auto()
+#    AM_PM  = auto()
+#    YEAR   = auto()
+#    MONTH  = auto()
+#    DAY    = auto()
+#
+#START  = TimePart.START
+#DIGITS = TimePart.DIGITS
+#MINUTE = TimePart.MINUTE
+#SECOND = TimePart.SECOND
+#AM_PM  = TimePart.AM_PM
+#YEAR   = TimePart.YEAR
+#MONTH  = TimePart.MONTH
+#DAY    = TimePart.DAY
+
 
 
 DIGITS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
@@ -149,19 +172,19 @@ class _SmHhSsAm:
     # -------------------------------------------------------------------
     def run(self, stval, letter):
         """Run the discrete sm to search for pattern"""
-        msg = (f'LETTER({letter}) '
-               f'STCUR({stval} {self.stnum}) '
-               f'WORK({self.work}) '
-               f'LETTER({letter})')
-        #print('MSG:', msg)
+        #msg = (f'LETTER({letter}) '
+        #       f'STCUR({stval} {self.stnum}) '
+        #       f'WORK({self.work}) '
+        #       f'LETTER({letter})')
+        ##print('MSG:', msg)
         stval = self.dfa[stval](letter)
-        print(f'SM {msg} WORK({self.work}) STNXT({stval}) CAPTURE({self.capture})')
+        #print(f'SM {msg} WORK({self.work}) STNXT({stval}) CAPTURE({self.capture})')
         return stval
 
     def finish(self):
         """Finish finding time in text formatted as '5pm', '5:32am', '5:00:00', etc."""
         capture = self.capture
-        print(f'CAPTURE @ FINISH: {capture}')
+        #print(f'CAPTURE @ FINISH: {capture}')
         # Require that the hour is specified
         if 'hour' not in capture:
             self.capture = None


### PR DESCRIPTION
Examples of specific use cases included in 
100x speed improvement (microseconds, down from milliseconds)
for `--at` options such as
  * `trk start --at 9am`
  * `trk stop --at 5pm -m "Finished task"`

include:    
* 12am
* 12:30am
* 12:30:01am
* 06-10 12pm
* 06-10 12:30pm
* 06-10 12:30:01pm
* 2025-06-10 13
* 2025-06-10 13:30
* 2025-06-10 13:30:01